### PR TITLE
Update link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Before submitting a pull request please make sure all tests run by **Tests** run
 
 Please don't use class comments with information about author or date and time creation.
 
-For further information please see [the official plugin development page](http://confluence.jetbrains.net/display/IDEADEV/PluginDevelopment).
+For further information please see [the official plugin development page](http://www.jetbrains.org/intellij/sdk/docs/).
 Also you can read some [tips and tricks](http://tomaszdziurko.pl/2011/09/developing-plugin-intellij-idea-some-tips-and-links/).
 For all development questions and proposals you can mail to our [Google Group](https://groups.google.com/d/forum/intellij-erlang-dev).
 Happy hacking!


### PR DESCRIPTION
Use the current link to the IntelliJ plugin/SDK development documentation (old one redirects to new one).